### PR TITLE
Wsl rstudio

### DIFF
--- a/rocker-rstudio-jp/Taskfile.yml
+++ b/rocker-rstudio-jp/Taskfile.yml
@@ -1,0 +1,21 @@
+version: '3'
+
+env:
+  IMAGE_NAME_HUB: yuheitomi/rocker-rstudio-jp:latest
+  IMAGE_NAME_LOCAL: rstudio-local
+  CONTAINER_NAME: rocker-rstudio
+
+tasks:
+  up-hub:
+    env:
+      IMAGE_NAME: '{{.IMAGE_NAME_HUB}}'
+    cmds:
+      - docker compose up -d
+    desc: Start the Docker container image on Docker Hub in detached mode
+
+  up-local:
+    env:
+      IMAGE_NAME: '{{.IMAGE_NAME_LOCAL}}'
+    cmds:
+      - docker compose up -d
+    desc: Start the local Docker containers image in detached mode

--- a/rocker-rstudio-jp/build-local.sh
+++ b/rocker-rstudio-jp/build-local.sh
@@ -1,0 +1,2 @@
+docker pull rocker/rstudio:4.4
+docker build . -t rstudio-local

--- a/rocker-rstudio-jp/compose.yml
+++ b/rocker-rstudio-jp/compose.yml
@@ -1,0 +1,23 @@
+services:
+    rstudio:
+        image: ${IMAGE_NAME:-yuheitomi/rocker-rstudio-jp:latest}
+        container_name: ${CONTAINER_NAME:-rocker-rstudio-jp}
+        ports:
+            - "8787:8787"
+        environment:
+            - LC_ALL=en_US.UTF-8
+            - TZ=Asia/Tokyo
+            - ROOT=true
+            - PASSWORD=password
+            - DISABLE_AUTH=true
+            - RENV_CONFIG_PAK_ENABLED=TRUE
+            - RENV_PATHS_ROOT=/home/rstudio/.cache/R/renv
+        volumes:
+            - ./workspace:/home/rstudio/workspace
+            - ./utils:/home/rstudio/utils
+            - $HOME/.cache/R/renv:/home/rstudio/.cache/R/renv
+            - $HOME/.cache/R/pkgcache:/home/rstudio/.cache/R/pkgcache
+            - $HOME/.cache/rstudio-server:/home/rstudio/.cache/rstudio
+            - $HOME/.config/rstudio-server:/home/rstudio/.config/rstudio
+            - $HOME/.config/github-copilot:/home/rstudio/.config/github-copilot
+        restart: unless-stopped


### PR DESCRIPTION
This pull request introduces a Docker setup for the `rocker-rstudio-jp` project, including task automation, container configuration, and local image building. The most important changes include the addition of a task file for Docker commands, a script for building a local Docker image, and a Docker Compose configuration for the RStudio service.

Docker setup and task automation:

* [`rocker-rstudio-jp/Taskfile.yml`](diffhunk://#diff-83cfc13155c1ca27a745073a63a20195a37308fbe48a7057402ed1e8e00fa554R1-R21): Added a task file to automate Docker commands, including tasks for starting the Docker container from Docker Hub and a local image in detached mode.

Local Docker image building:

* [`rocker-rstudio-jp/build-local.sh`](diffhunk://#diff-7ac6b7b87632f10bcb0ceda2ab576a09fe202b3883cda5abe0ced4731fbd586eR1-R2): Added a script to pull the base RStudio image and build a local Docker image named `rstudio-local`.

Docker Compose configuration:

* [`rocker-rstudio-jp/compose.yml`](diffhunk://#diff-2dc0be27c6b66bedbe852a9feed42e59858e04ee71aa09e89b1d02624f09cbecR1-R23): Added a Docker Compose file to define the RStudio service, including environment variables, port mapping, volume mounts, and restart policy.